### PR TITLE
#4 Strict liho task should fail if an issue is found

### DIFF
--- a/src/main/groovy/ru/arsysop/liho/gradle/LihoCheckFailureException.groovy
+++ b/src/main/groovy/ru/arsysop/liho/gradle/LihoCheckFailureException.groovy
@@ -1,0 +1,8 @@
+package ru.arsysop.liho.gradle
+
+class LihoCheckFailureException extends Exception {
+
+    LihoCheckFailureException(VindictiveReport report) {
+        super(report.summary())
+    }
+}

--- a/src/main/groovy/ru/arsysop/liho/gradle/LihoCheckFailureException.groovy
+++ b/src/main/groovy/ru/arsysop/liho/gradle/LihoCheckFailureException.groovy
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
 package ru.arsysop.liho.gradle
 
 class LihoCheckFailureException extends Exception {

--- a/src/main/groovy/ru/arsysop/liho/gradle/LihoPlugin.groovy
+++ b/src/main/groovy/ru/arsysop/liho/gradle/LihoPlugin.groovy
@@ -22,18 +22,21 @@ package ru.arsysop.liho.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 
 @SuppressWarnings("unused")
 class LihoPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        project.apply([plugin: 'base'])
         project.extensions.create('liho', Configuration)
-        project.task([type: LihoTask], 'liho') {
+        Task liho = project.task([type: LihoTask], 'liho') {
             root.set(project.liho.root)
             strict.set(project.liho.strict)
             report.set(project.liho.report)
         }
+        project.tasks.getByName("check").dependsOn(liho)
     }
 
 }

--- a/src/main/groovy/ru/arsysop/liho/gradle/VindictiveReport.groovy
+++ b/src/main/groovy/ru/arsysop/liho/gradle/VindictiveReport.groovy
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package ru.arsysop.liho.gradle
+
+import groovy.transform.PackageScope
+import ru.arsysop.liho.report.IssueLocation
+import ru.arsysop.liho.report.IssueType
+import ru.arsysop.liho.report.Report
+import ru.arsysop.liho.report.StreamingReport
+
+import java.util.concurrent.atomic.AtomicInteger
+
+@PackageScope
+class VindictiveReport implements Report {
+
+    private final StreamingReport delegate
+    private final File file
+    private final AtomicInteger counter = new AtomicInteger(0)
+
+    VindictiveReport(File file, OutputStream output) {
+        this.file = file
+        this.delegate = new StreamingReport(new PrintStream(output))
+    }
+
+    @Override
+    void issue(IssueType type, IssueLocation location) {
+        counter.incrementAndGet()
+        delegate.issue(type, location)
+    }
+
+    int issues() {
+        counter.get()
+    }
+
+    boolean failed() {
+        issues() > 0
+    }
+
+    String summary() {
+        "LiHo found ${issues()} license header issues. Have a closer look at the report ${file.getAbsolutePath()}"
+    }
+
+}


### PR DESCRIPTION
  - throw TaskExecutionException in strict case
  - print warning with the same summary to system error stream otherwise

Side changes:  
 - `base` plugin is applied autpmatically to the target project
 - `liho` task is bound to `base:check` verification meta task. Thus,
```
./gradlew check
```
will trigger `liho` together with `test`  and other verification tasks.