### PR TITLE
 #9 Get git of hardcoded 'liho' repository url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ if a project source base is sufficiently equipped with license headers.
 
 **Currently is under construction.**
 
-#### to build
+#### to publish
 ```
 ./gradlew publish
 ```
-
+It builds and stores publish-ready artifacts into _buildDir/local-repo_.
+ 
 #### to apply
 1. _apply_ the plugin in _plugins_ block of your `build.gradle`
     ```groovy
@@ -29,8 +30,7 @@ if a project source base is sufficiently equipped with license headers.
    ```groovy
     pluginManagement {
         repositories {
-            ...
-            maven(url = "https://dl.bintray.com/arsysop/lang")
+            jcenter()
         }
         resolutionStrategy {
             eachPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-
 plugins {
     id 'java-gradle-plugin'
     id 'groovy'
@@ -30,12 +29,6 @@ version = currentVersion
 
 repositories {
     jcenter()
-    maven {
-        url = "https://dl.bintray.com/arsysop/lang"
-    }
-    maven {
-        url = "https://dl.bintray.com/arsysop/liho"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
- LiHo search repository is switched to jcenter
- readme is updated